### PR TITLE
Code Cleanup and Bug Fixes for Import Errors and Window Closure

### DIFF
--- a/Utils/ConfigurationManager.py
+++ b/Utils/ConfigurationManager.py
@@ -1,6 +1,6 @@
 import configparser
 
-import Utils.Mode as Mode
+from Utils.Mode import Mode
 
 class ConfigurationManager:
     def __init__(self):

--- a/Utils/HALightChanger.py
+++ b/Utils/HALightChanger.py
@@ -1,9 +1,9 @@
 import requests
 
-import Utils.ILightChanger as ILightChanger
-import Utils.RGBToHSVConverter as RGBToHSVConverter
+from Utils.ILightChanger import ILightChanger
+from Utils.RGBToHSVConverter import RGBToHSVConverter
 
-class HALightChanger(ILightChanger.ILightChanger):
+class HALightChanger(ILightChanger):
     def __init__(self, home_assistant_ip, home_assistant_port):
         self.home_assistant_ip = home_assistant_ip
         self.home_assistant_port = home_assistant_port

--- a/Utils/WLEDLightChanger.py
+++ b/Utils/WLEDLightChanger.py
@@ -1,7 +1,7 @@
-import Utils.ILightChanger as ILightChanger
+from Utils.ILightChanger import ILightChanger
 import socket
 
-class WLEDLightChanger(ILightChanger.ILightChanger):
+class WLEDLightChanger(ILightChanger):
     def __init__(self, wledIP):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.protocol = 1

--- a/Utils/YeeLightChanger.py
+++ b/Utils/YeeLightChanger.py
@@ -1,10 +1,10 @@
 from yeelight import *
 import time
 
-import Utils.ILightChanger as ILightChanger
-import Utils.RGBToHSVConverter as RGBToHSVConverter
+from Utils.ILightChanger import ILightChanger
+from Utils.RGBToHSVConverter import RGBToHSVConverter
 
-class YeeLightChanger(ILightChanger.ILightChanger):
+class YeeLightChanger(ILightChanger):
     def __init__(self, yeelightIP):
         self.rgbToHSVConverter = RGBToHSVConverter()
         

--- a/Windows/MainWindow.py
+++ b/Windows/MainWindow.py
@@ -2,7 +2,6 @@ import PySimpleGUI as sg
 
 import Utils.ConfigurationManager as ConfigurationManager
 from Utils.LightChangerResolver import LightChangerResolver
-from Utils.ILightChanger import ILightChanger
 from Utils.ScreenReader import ScreenReader
 from Utils.RGBToHSVConverter import RGBToHSVConverter
 from Windows.SettingsWindow import SettingsWindow
@@ -68,21 +67,22 @@ class MainWindow:
 
 
         window = self.renderLayout(theme, refreshRate, colorPrecision)
-        running = False # Wether the light sync is running or not
+        running = False # Whether the light sync is running or not
 
         while True:
             event, values = window.read(refreshRate) # I reccomend using 150ms for YeeLight Mode and 1000ms on HA mode (higher latency)
             # print(event, values) # Shows GUI state (for debugging)
+            
+            if event == sg.WIN_CLOSED or values is None: # if user closes window
+                self.lightChanger.defaultColor()
+                break
+
             max_br = values["MAX-BRIGHTNESS"]
             vary_br = values["VARY-BRIGHTNESS"]
             sc = self.screens_list.index(values['SCREENS-LIST'])
 
             if event == 'Start': # if user clicks start
                 running = True
-
-            if event == sg.WIN_CLOSED: # if user closes window
-                self.lightChanger.defaultColor()
-                break
 
             if event == 'Stop': # if user clicks stop
                 self.lightChanger.defaultColor()

--- a/Windows/SettingsWindow.py
+++ b/Windows/SettingsWindow.py
@@ -4,8 +4,6 @@ import time
 import Utils.ConfigurationManager as ConfigurationManager, Utils.ILightChanger as ILightChanger, Utils.Mode as Mode
 from Utils.YeeLightBulbFinder import YeeLightBulbFinder
 from Utils.LightChangerResolver import LightChangerResolver
-from Utils.HALightChanger import HALightChanger
-from Utils.YeeLightChanger import YeeLightChanger
 
 class SettingsWindow:
     def __init__(self, configManager : ConfigurationManager, lightChangerResolver: LightChangerResolver, yeeLightBulbFinder: YeeLightBulbFinder):


### PR DESCRIPTION
### Pull Request Summary: Code Cleanup and Bug Fixes for Import Errors and Window Closure

**Summary:**
This pull request addresses issues related to import errors, window closure crashes, and unused imports in the RSI application. Key improvements include fixing the import logic, reorganizing the window closure handling, and removing unused imports for cleaner code.

**Changes Made:**

1. Fixed Window Closure Crash
- _What Changed:_ Moved the location of the "Window Closed" break statement.
- _Why:_ Prevented an error that occurred whenever the user closed the main window.

2. Removed Unused Imports
- _What Changed:_ Removed unnecessary import statements across multiple files.
- _Why:_ Improved code readability and reduced potential for future conflicts.

3. Corrected Import Statements
- _What Changed:_ Corrected import statements to ensure class-specific imports rather than importing entire modules.
- Example Fix:
```
  Old (Incorrect): import Utils.RGBToHSVConverter as RGBToHSVConverter

  New (Correct): from Utils.RGBToHSVConverter import RGBToHSVConverter
```

- _Why:_ This resolves the crash when switching from WLED to HomeAssistant, ensuring that RGBToHSVConverter is imported correctly as a class, not as a module reference.

**Issue Reference:**
Related to Issue #3 (https://github.com/RonFalafel/RSI/issues/3)

**Testing Performed:**
Manually tested switching between WLED and HomeAssistant modes without any crashes.

Let me know if further improvements are needed. Thank you!